### PR TITLE
Remove authentication

### DIFF
--- a/app/controllers/AttachmentApp.java
+++ b/app/controllers/AttachmentApp.java
@@ -7,7 +7,6 @@
 package controllers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import controllers.annotation.AnonymousCheck;
 import models.Attachment;
 import models.User;
 import models.enumeration.Operation;
@@ -33,7 +32,6 @@ import java.util.Map;
 
 import static play.libs.Json.toJson;
 
-@AnonymousCheck
 public class AttachmentApp extends Controller {
 
     public static final String TAG_NAME_FOR_TEMPORARY_UPLOAD_FILES = "temporaryUploadFiles";
@@ -138,10 +136,6 @@ public class AttachmentApp extends Controller {
         }
 
         String eTag = "\"" + attachment.hash + "-" + dispositionType + "\"";
-
-        if (!AccessControl.isAllowed(UserApp.currentUser(), attachment.asResource(), Operation.READ)) {
-            return forbidden("You have no permission to get the file.");
-        }
 
         response().setHeader("Cache-Control", "private, max-age=3600");
 


### PR DESCRIPTION
Jira 첨부파일 이전 예상 시나리오입니다.

1. 요나 프로세스 중지
2. 요나 서버 80 포트 차단 및 Jira ip에만 개방
3. 파일 접근 시 인증 없는 요나 설치 및 가동
4. Jira에서 url을 통해 파일 이전
5. 3, 2, 1 롤백